### PR TITLE
Update concurrent.py for proper callbacks processing in class Future, method _set_done()

### DIFF
--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -323,7 +323,7 @@ class Future(object):
             except Exception:
                 app_log.exception('Exception in callback %r for %r',
                                   cb, self)
-        self._callbacks = None
+        self._callbacks = []
 
     # On Python 3.3 or older, objects with a destructor part of a reference
     # cycle are never destroyed. It's no longer the case on Python 3.4 thanks to


### PR DESCRIPTION
In ****init**()** method **self._callbacks = []** indicate that no callbacks exist. But in method **_set_done()**, after calling of all callbacks, set **self._callbacks = None** may cause exception in case of reuse of **Future** instance.
